### PR TITLE
Disable ambient sounds

### DIFF
--- a/xrSound/Sound.h
+++ b/xrSound/Sound.h
@@ -39,6 +39,7 @@ XRSOUND_API extern float			psSoundOcclusionScale	;
 XRSOUND_API extern Flags32			psSoundFlags			;
 XRSOUND_API extern int				psSoundTargets			;
 XRSOUND_API extern int				psSoundCacheSizeMB		;
+XRSOUND_API extern int				psSoundAmbient			;
 
 // Flags
 enum {

--- a/xrSound/SoundRender_Core.cpp
+++ b/xrSound/SoundRender_Core.cpp
@@ -22,6 +22,7 @@ float	psSoundVFactor			= 1.0f;
 
 float	psSoundVMusic			= 0.7f;
 int		psSoundCacheSizeMB		= 16;
+int		psSoundAmbient			= 1;
 
 CSoundRender_Core*				SoundRender = 0;
 CSound_manager_interface*		Sound		= 0;

--- a/xr_3da/Rain.cpp
+++ b/xr_3da/Rain.cpp
@@ -133,12 +133,13 @@ void	CEffect_Rain::OnFrame	()
 	{
 	case stIdle:		
 		if (factor<EPS_L)		return;
+		if (!psSoundAmbient)	return;
 		state					= stWorking;
 		snd_Ambient.play		(0,sm_Looped);
 		snd_Ambient.set_range	(source_offset,source_offset*2.f);
 	break;
 	case stWorking:
-		if (factor<EPS_L){
+		if (factor<EPS_L || !psSoundAmbient){
 			state				= stIdle;
 			snd_Ambient.stop	();
 			return;
@@ -147,7 +148,7 @@ void	CEffect_Rain::OnFrame	()
 	}
 
 	// ambient sound
-	if (snd_Ambient._feedback()){
+	if (psSoundAmbient && snd_Ambient._feedback()){
 		Fvector					sndP;
 		sndP.mad				(Device.vCameraPosition,Fvector().set(0,1,0),source_offset);
 		snd_Ambient.set_position(sndP);
@@ -199,7 +200,7 @@ void	CEffect_Rain::Render	()
 		if (one.dwTime_Hit<Device.dwTimeGlobal)		Hit (one.Phit);
 		if (one.dwTime_Life<Device.dwTimeGlobal)	Born(one,source_radius);
 
-// последняя дельта ??
+// пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ ??
 //.		float xdt		= float(one.dwTime_Hit-Device.dwTimeGlobal)/1000.f;
 //.		float dt		= Device.fTimeDelta;//xdt<Device.fTimeDelta?xdt:Device.fTimeDelta;
 		float dt		= Device.fTimeDelta;

--- a/xr_3da/xrGame/GamePersistent.cpp
+++ b/xr_3da/xrGame/GamePersistent.cpp
@@ -210,7 +210,7 @@ void CGamePersistent::WeathersUpdate()
 		CEnvAmbient* env_amb		= _env->env_ambient;
 		if (env_amb){
 			// start sound
-			if (Device.dwTimeGlobal > ambient_sound_next_time){
+			if (psSoundAmbient && Device.dwTimeGlobal > ambient_sound_next_time){
 				ref_sound* snd			= env_amb->get_rnd_sound();
 				ambient_sound_next_time	= Device.dwTimeGlobal + env_amb->get_rnd_sound_time();
 				if (snd){

--- a/xr_3da/xr_ioc_cmd.cpp
+++ b/xr_3da/xr_ioc_cmd.cpp
@@ -586,13 +586,14 @@ void CCC_Register()
 	// Sound
 	CMD2(CCC_Float,		"snd_volume_eff",		&psSoundVEffects);
 	CMD2(CCC_Float,		"snd_volume_music",		&psSoundVMusic);
-//.	CMD3(CCC_Token,		"snd_freq",				&psSoundFreq,		snd_freq_token			);
-//.	CMD3(CCC_Token,		"snd_model",			&psSoundModel,		snd_model_token			);
+	CMD4(CCC_Integer,	"snd_ambient",			&psSoundAmbient,	0, 1);
+//.	CMD3(CCC_Token,		"snd_freq",				&psSoundFreq,			snd_freq_token				);
+//.	CMD3(CCC_Token,		"snd_model",				&psSoundModel,		snd_model_token				);
 	CMD1(CCC_SND_Restart,"snd_restart"			);
 	CMD3(CCC_Mask,		"snd_acceleration",		&psSoundFlags,		ss_Hardware	);
 	CMD3(CCC_Mask,		"snd_efx",				&psSoundFlags,		ss_EAX		);
-	CMD4(CCC_Integer,	"snd_targets",			&psSoundTargets,	4,32		);
-	CMD4(CCC_Integer,	"snd_cache_size",		&psSoundCacheSizeMB,4,32		);
+	CMD4(CCC_Integer,	"snd_targets",			&psSoundTargets,	4,32			);
+	CMD4(CCC_Integer,	"snd_cache_size",		&psSoundCacheSizeMB,4,32			);
 
 #ifdef DEBUG
 	CMD3(CCC_Mask,		"snd_stats",			&g_stats_flags,		st_sound	);
@@ -602,7 +603,7 @@ void CCC_Register()
 	CMD3(CCC_Mask,		"snd_stats_info_name",	&g_stats_flags,		st_sound_info_name );
 	CMD3(CCC_Mask,		"snd_stats_info_object",&g_stats_flags,		st_sound_info_object );
 
-	CMD4(CCC_Integer,	"error_line_count",		&g_ErrorLineCount,	6,	1024	);
+	CMD4(CCC_Integer,	"error_line_count",	&g_ErrorLineCount,	6,	1024		);
 #endif // DEBUG
 
 	// Mouse


### PR DESCRIPTION
Add `snd_ambient` console variable to disable ambient sounds.

This PR introduces a new console variable `snd_ambient` (default 1) to globally control ambient sound playback. It guards ambient sound triggers in `CGamePersistent::WeathersUpdate` and rain ambience playback/updates in `CEffect_Rain` based on this toggle.

---
<a href="https://cursor.com/background-agent?bcId=bc-672a7fd7-e400-4037-a236-35d8bc9f4b05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-672a7fd7-e400-4037-a236-35d8bc9f4b05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

